### PR TITLE
BREAKING: force extensions

### DIFF
--- a/node.js
+++ b/node.js
@@ -67,6 +67,7 @@ export default defineConfig(
 				"error",
 				{ allow: builtinModules.map((mod) => `node:${mod}`) },
 			],
+			"import-x/extensions": ["error", "ignorePackages"],
 		},
 	},
 );

--- a/react.js
+++ b/react.js
@@ -90,6 +90,7 @@ export default defineConfig(
 				"error",
 				{ allow: builtinModules.map((mod) => `node:${mod}`) },
 			],
+			"import-x/extensions": ["error", "ignorePackages"],
 
 			"react/prop-types": "off",
 		},


### PR DESCRIPTION
Force imports with extensions for compatibility with Node's builtin TypeScript support.